### PR TITLE
Add unit test for sort fra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.so
+*.egg-info/

--- a/fraglets.cpp
+++ b/fraglets.cpp
@@ -942,6 +942,27 @@ void fraglets::drawGraphViz(){
     gvFreeContext(graphContext);
 }
 
+std::vector<std::string> fraglets::getSorted(){
+    std::vector<std::string> result;
+    auto extract = [&result](keyMultisetMap &km){
+        for(auto &kv : km){
+            moleculeMultiset *mset = kv.second;
+            for(auto mol : mset->multiset){
+                if(!mol->vector.empty() && *(mol->vector[0]) == "sorted"){
+                    for(size_t i=1;i<mol->vector.size();++i){
+                        result.push_back(*(mol->vector[i]));
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+    if(extract(this->active.keyMap)) return result;
+    extract(this->passive.keyMap);
+    return result;
+}
+
 
 
 

--- a/fraglets.h
+++ b/fraglets.h
@@ -86,6 +86,7 @@ class fraglets {
         void interpret(std::string filename);
         void trace();
         void drawGraphViz();
+        std::vector<std::string> getSorted();
         int iter = 0;
         
 

--- a/fraglets.py
+++ b/fraglets.py
@@ -34,6 +34,9 @@ class fraglets():
     def drawGraphViz(self):
         cFraglets.drawGraphViz(self.cfraglets)
 
+    def get_sorted(self):
+        return cFraglets.getSorted(self.cfraglets)
+
 
     def __delete__(self):
         cFraglets.delete_object(self.cfraglets)

--- a/fragletsToPy.cpp
+++ b/fragletsToPy.cpp
@@ -108,6 +108,31 @@ PyObject* getUnimolTags(PyObject* self, PyObject* args)
     return tags;
 }
 
+PyObject* getSorted(PyObject* self, PyObject* args)
+{
+    PyObject* fragletsCapsule_;
+
+    PyArg_ParseTuple(args, "O",
+                     &fragletsCapsule_);
+
+    fraglets* frag = (fraglets*)PyCapsule_GetPointer(fragletsCapsule_, "fragletsPtr");
+
+    std::vector<std::string> vec = frag->getSorted();
+    PyObject* list = PyList_New(vec.size());
+    for(size_t i=0;i<vec.size();++i){
+        const std::string &sym = vec[i];
+        PyObject* item;
+        try{
+            int v = std::stoi(sym);
+            item = PyLong_FromLong(v);
+        }catch(...){
+            item = Py_BuildValue("s", sym.c_str());
+        }
+        PyList_SetItem(list, i, item);
+    }
+    return list;
+}
+
 
 PyObject* delete_object(PyObject* self, PyObject* args)
 {
@@ -145,6 +170,8 @@ static PyMethodDef fragletsFunctions[] =
     "gets the current number of iterations"},
     {"drawGraphViz",drawGraphViz,METH_VARARGS,
     "draws graph"},
+    {"getSorted",getSorted,METH_VARARGS,
+    "returns sorted list"},
     {"delete_object",               // C++/Py Destructor
       delete_object, METH_VARARGS,
      "Delete `fraglets` object"},

--- a/test_sort.py
+++ b/test_sort.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+import fraglets
+
+class SortFraTest(unittest.TestCase):
+    def test_sort_fra_runs(self):
+        f = fraglets.fraglets()
+        sort_path = os.path.join(os.path.dirname(__file__), 'sort.fra')
+        nums = []
+        with open(sort_path) as fh:
+            for line in fh:
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    f.parse(line)
+                if line.startswith('[sort'):
+                    parts = line.strip('[]').split()
+                    nums = list(map(int, parts[1:]))
+        f.run(10000, 10000, True)
+        result = f.get_sorted()
+        self.assertEqual(len(result), len(nums))
+        self.assertTrue(all(result[i] <= result[i+1] for i in range(len(result)-1)))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `.gitignore` to skip build artifacts
- add `getSorted` functionality to expose sorted numbers from C++
- add a wrapper in Python and new `get_sorted` method
- update `test_sort.py` to verify the numbers are sorted after running the program

## Testing
- `python3 -m unittest test_sort.py`


------
https://chatgpt.com/codex/tasks/task_e_68732480dc1083249d56f84cfe27de4d